### PR TITLE
Quoted conditionals create block

### DIFF
--- a/lib/erbse/parser.rb
+++ b/lib/erbse/parser.rb
@@ -3,7 +3,7 @@ module Erbse
     # ERB_EXPR = /<%(=|\#)?(.*?)%>(\n)*/m # this is the desired pattern.
     ERB_EXPR = /<%(=+|-|\#|@\s|%)?(.*?)[-=]?%>(\n)*/m # this is for backward-compatibility.
     # BLOCK_EXPR     = /\s*((\s+|\))do|\{)(\s*\|[^|]*\|)?\s*\Z/
-    BLOCK_EXPR = /\b(if|unless)\b|\sdo\s*$|\sdo\s+\|/
+    BLOCK_EXPR = /\A\s*(if|unless)\b|\sdo\s*$|\sdo\s+\|/
 
     # Parsing patterns
     #

--- a/test/erbse_test.rb
+++ b/test/erbse_test.rb
@@ -135,6 +135,22 @@ blubb</b>} }
     it { Erbse::Parser.new.(%{<% form do |i| %>1<% end %>}).must_equal [:multi, [:block, " form do |i| ", [:multi, [:static, "1"]]]] }
   end
 
+  describe "quoted conditional" do
+    let (:str2) { %{
+  <%= form_for do %>
+    <%= link_to "string", path, "v-if" => "trigger" %>
+  <% end %>}
+    }
+
+    it "parses quoted conditionals correctly" do
+      Erbse::Parser.new.(str2).must_equal [:multi,
+        [:erb, :block, " form_for do ", [:multi,
+          [:newline],
+          [:dynamic, " link_to \"string\", path, \"v-if\" => \"trigger\" "],
+          [:newline]]]]
+    end
+  end
+
   describe "<%@ %>" do
     let (:str) { %{<%@ content = capture do %>
   Yo!


### PR DESCRIPTION
This is just a failing spec to show the problem. Basically, we use Vue.js in our apps and it has a custrom attribute "v-if" - and it looks like erbse either treats it like a block while parsing, or does some other weird thing. I might have more time on debugging and providing a fix here, for now I just wanted to let you know this problem exists and provide failing test.

@apotonick do you know if there a quick fix for that, before I dig deeper into parser's code?

```

  1) Failure:
quoted conditional#test_0001_parses quoted conditionals correctly [/home/kshirinkin/work/opensource/erbse/test/erbse_test.rb:146]:
--- expected
+++ actual
@@ -1 +1 @@
-[:multi, [:erb, :block, " form_for do ", [:multi, [:newline], [:dynamic, " link_to \"string\", path, \"v-if\" => \"trigger\" "], [:newline]]]]
+[:multi, [:newline], [:erb, :block, " link_to \"string\", path, \"v-if\" => \"trigger\" ", [:multi, [:newline]]]]
```