### PR TITLE
fix do block detection with multiline { and }

### DIFF
--- a/lib/erbse/parser.rb
+++ b/lib/erbse/parser.rb
@@ -34,7 +34,7 @@ module Erbse
         end
 
         if ch == ?= # <%= %>
-          if code =~ BLOCK_EXPR
+          if code =~ BLOCK_EXEC
             buffers.last << [:erb, :block, code, block = [:multi]] # picked up by our own BlockFilter.
             buffers << block
           else


### PR DESCRIPTION
In my rails project I am using cells.  After updating to Erbse 0.1.2 when I rendered my template there was this error:

    undefined method `<<' for nil:NilClass

I traced the problem to erbse/lib/parser.rb.  After playing with the code a bit and comparing parser.rb in v0.1.1 to the current parser.rb I found that this change solved my problem.  I also noticed that before this change the final closing <% } %> was incorrectly matched.

