### PR TITLE
Fix line numbers in generated code

### DIFF
--- a/test/erbse_test.rb
+++ b/test/erbse_test.rb
@@ -16,22 +16,28 @@ Text
 
   it "what" do
     Erbse::Parser.new.(str).must_equal [:multi,
-      [:static, "\n"],
-      [:dynamic, " true "], [:newline],
-      [:static, "Text\n"],
+      [:static, "\n"], [:newline],
+      [:dynamic, " true "],
+      [:static, "\n"], [:newline],
+      [:static, "Text\n"], [:newline],
       [:erb, :block, " form_for do ", [:multi,
         [:dynamic, " 1 "],
-        [:code, " 2 "], [:newline],
+        [:code, " 2 "], 
+        [:static, "\n"], [:newline],
         [:static, "  "],
-        [:erb, :block, " nested do ", [:multi, [:newline],
+        [:erb, :block, " nested do ", [:multi, 
+          [:static, "\n"], [:newline],
           [:static, "    "],
-          [:dynamic, " this "], [:newline],
-          [:static, "    <a/>\n  "],
-          ]], [:newline]]]]
+          [:dynamic, " this "],
+          [:static, "\n"], [:newline],
+          [:static, "    <a/>\n"], [:newline],
+          [:static, "  "],
+          ]], 
+        [:static, "\n"], [:newline]]]]
   end
 
   it "generates ruby" do
-      code = %{_buf = []; _buf << ("@@".freeze); _buf << ( true ); @; _buf << ("Text@@".freeze); _erbse_blockfilter1 =  form_for do ; _erbse_blockfilter2 = ''; _erbse_blockfilter2 << (( 1 ).to_s);  2 ; @; _erbse_blockfilter2 << ("  ".freeze); _erbse_blockfilter3 =  nested do ; _erbse_blockfilter4 = ''; @; _erbse_blockfilter4 << ("    ".freeze); _erbse_blockfilter4 << (( this ).to_s); @; _erbse_blockfilter4 << ("    <a/>@@  ".freeze); _erbse_blockfilter4; end; _erbse_blockfilter2 << ((_erbse_blockfilter3).to_s); @; _erbse_blockfilter2; end; _buf << (_erbse_blockfilter1); _buf = _buf.join("".freeze)}
+      code = %{_buf = []; _buf << (\"@@\".freeze); @; _buf << ( true ); _buf << (\"@@\".freeze); @; _buf << (\"Text@@\".freeze); @; _erbse_blockfilter1 =  form_for do ; _erbse_blockfilter2 = ''; _erbse_blockfilter2 << (( 1 ).to_s);  2 ; _erbse_blockfilter2 << (\"@@\".freeze); @; _erbse_blockfilter2 << (\"  \".freeze); _erbse_blockfilter3 =  nested do ; _erbse_blockfilter4 = ''; _erbse_blockfilter4 << (\"@@\".freeze); @; _erbse_blockfilter4 << (\"    \".freeze); _erbse_blockfilter4 << (( this ).to_s); _erbse_blockfilter4 << (\"@@\".freeze); @; _erbse_blockfilter4 << (\"    <a/>@@\".freeze); @; _erbse_blockfilter4 << (\"  \".freeze); _erbse_blockfilter4; end; _erbse_blockfilter2 << ((_erbse_blockfilter3).to_s); _erbse_blockfilter2 << (\"@@\".freeze); @; _erbse_blockfilter2; end; _buf << (_erbse_blockfilter1); _buf = _buf.join(\"\".freeze)}
     ruby = Erbse::Engine.new.(str).gsub("\n", "@").gsub('\n', "@@")
     # puts ruby
     ruby.must_equal code
@@ -51,26 +57,33 @@ Text
     }
     it "what" do
       Erbse::Parser.new.(str).must_equal [:multi,
-        [:static, "\n"],
+        [:static, "\n"], [:newline],
         [:block, " 2.times do |i| ", [:multi,
-          [:newline],
+          [:static, "\n"], [:newline],
           [:static, "  "],
-          [:dynamic, " i+1 "], [:newline], [:static, "  "],
-          [:code, " puts "], [:newline]]], [:newline],
-        [:block, " if 1 == 1 ", [:multi, [:newline],
-          [:static, "  Hello\n"]]], [:newline]]
+          [:dynamic, " i+1 "], 
+          [:static, "\n"], [:newline], [:static, "  "],
+          [:code, " puts "], 
+          [:static, "\n"], [:newline]
+          ]],
+          [:static, "\n"], [:newline],
+          [:static, "\n"], [:newline],
+        [:block, " if 1 == 1 ", [:multi,
+          [:static, "\n"], [:newline],
+          [:static, "  Hello\n"], [:newline]]],
+          [:static, "\n"], [:newline]]
     end
 
     it do
       ruby = Erbse::Engine.new.(str)
       ruby = ruby.gsub("\n", "@")
       # ruby.must_equal %{_buf = [];  self ;  2.times do |i| ; _buf << ( i+1 );  puts ; end; _buf = _buf.join(\"\".freeze)}
-      ruby.must_equal '_buf = []; _buf << ("\n".freeze);  2.times do |i| ; @; _buf << ("  ".freeze); _buf << ( i+1 ); @; _buf << ("  ".freeze);  puts ; @; end; @;  if 1 == 1 ; @; _buf << ("  Hello\n".freeze); end; @; _buf = _buf.join("".freeze)'
+      ruby.must_equal '_buf = []; _buf << ("\n".freeze); @;  2.times do |i| ; _buf << ("\n".freeze); @; _buf << ("  ".freeze); _buf << ( i+1 ); _buf << ("\n".freeze); @; _buf << ("  ".freeze);  puts ; _buf << ("\n".freeze); @; end; _buf << ("\n".freeze); @; _buf << ("\n".freeze); @;  if 1 == 1 ; _buf << ("\n".freeze); @; _buf << ("  Hello\n".freeze); @; end; _buf << ("\n".freeze); @; _buf = _buf.join("".freeze)'
     end
 
     it do
       ruby = Erbse::Engine.new.(str)
-      eval(ruby).must_equal "\n  1    2    Hello\n"
+      eval(ruby).must_equal "\n\n  1\n  \n\n  2\n  \n\n\n\n  Hello\n\n"
     end
   end
 
@@ -78,7 +91,7 @@ Text
     let (:str) { %{Holla
 Hi}
     }
-    it { Erbse::Parser.new.(str).must_equal [:multi, [:static, "Holla\nHi"]] }
+    it { Erbse::Parser.new.(str).must_equal [:multi, [:static, "Holla\n"], [:newline], [:static, "Hi"]] }
   end
 
   # comments
@@ -93,12 +106,12 @@ Hi
 } }
 
     it do
-      Erbse::Parser.new.(str).must_equal [:multi, [:static, "Hello\n"], [:newline], [:static, "Hola\n"], [:newline], [:newline], [:static, "Hi\n"], [:code, " # this "], [:newline]]
+      Erbse::Parser.new.(str).must_equal [:multi, [:static, "Hello\n"], [:newline], [:static, "\n"], [:newline], [:static, "Hola\n"], [:newline], [:newline], [:static, "\n"], [:newline], [:static, "Hi\n"], [:newline], [:code, " # this "], [:static, "\n"], [:newline]]
     end
 
     it do
       ruby = Erbse::Engine.new.(str).gsub("\n", "@").gsub('\n', "@@")
-      code = %{_buf = []; _buf << ("Hello@@".freeze); @; _buf << ("Hola@@".freeze); @; @; _buf << ("Hi@@".freeze);  # this ; @; _buf = _buf.join("".freeze)}
+      code = %{_buf = []; _buf << (\"Hello@@\".freeze); @; _buf << (\"@@\".freeze); @; _buf << (\"Hola@@\".freeze); @; @; _buf << (\"@@\".freeze); @; _buf << (\"Hi@@\".freeze); @;  # this ; _buf << (\"@@\".freeze); @; _buf = _buf.join(\"\".freeze)}
       ruby.must_equal code
     end
 
@@ -106,14 +119,14 @@ Hi
     it { Erbse::Parser.new.(%{Yo
 <%# bla do %>
 <%# end %>
-1}).must_equal [:multi, [:static, "Yo\n"], [:newline], [:newline], [:static, "1"]] }
+1}).must_equal [:multi, [:static, "Yo\n"], [:newline], [:static, "\n"], [:newline], [:static, "\n"], [:newline], [:static, "1"]] }
   end
 
   describe "content after last ERB tag" do
     let (:str) { %{<b><%= 1 %>bla
 blubb</b>} }
 
-    it { Erbse::Parser.new.(str).must_equal [:multi, [:static, "<b>"], [:dynamic, " 1 "], [:static, "bla\nblubb</b>"]] }
+    it { Erbse::Parser.new.(str).must_equal [:multi, [:static, "<b>"], [:dynamic, " 1 "], [:static, "bla\n"], [:newline], [:static, "blubb</b>"]] }
   end
 
   describe "<%* %>" do
@@ -177,14 +190,40 @@ blubb</b>} }
 
     it "parses quoted conditionals correctly" do
       Erbse::Parser.new.(str2).must_equal [:multi,
-        [:static, "\n  "],
+        [:static, "\n"],
+        [:newline],
+        [:static, "  "],
         [:erb, :block, " form_for do ", [:multi,
+          [:static, "\n"],
           [:newline],
           [:static, "    "],
           [:dynamic, " link_to \"string\", path, \"v-if\" => \"trigger\" "],
+          [:static, "\n"],
           [:newline],
           [:static, "  "]
         ]]]
+    end
+  end
+  
+  describe "newlines" do
+    let (:str2) { %{
+  abc
+  <%= 'foo' %>
+  def}
+    }
+
+    it "puts newlines after code" do
+      Erbse::Parser.new.(str2).must_equal [:multi,
+        [:static, "\n"],
+        [:newline],
+        [:static, "  abc\n"],
+        [:newline],
+        [:static, "  "],
+        [:dynamic, " 'foo' "],
+        [:static, "\n"],
+        [:newline],
+        [:static, '  def'],
+      ]
     end
   end
 
@@ -196,7 +235,7 @@ blubb</b>} }
 
     it do
       ruby = Erbse::Engine.new.(str).gsub("\n", "@").gsub('\n', "@@")
-      code = %{_buf = []; content = capture do ; _erbse_blockfilter1 = ''; @; _erbse_blockfilter1 << (\"  Yo!@@  \".freeze); _erbse_blockfilter1 << (( 1 ).to_s); @; _erbse_blockfilter1; end; _buf = _buf.join(\"\".freeze)}
+      code = %{_buf = []; content = capture do ; _erbse_blockfilter1 = ''; _erbse_blockfilter1 << (\"@@\".freeze); @; _erbse_blockfilter1 << (\"  Yo!@@\".freeze); @; _erbse_blockfilter1 << (\"  \".freeze); _erbse_blockfilter1 << (( 1 ).to_s); _erbse_blockfilter1 << (\"@@\".freeze); @; _erbse_blockfilter1; end; _buf = _buf.join(\"\".freeze)}
       ruby.must_equal code
     end
 


### PR DESCRIPTION
Erbse was reporting wrong line numbers when an error occured in the
generated code. Turns out the cause is that it is necessary to tag each
newline with the :newline tag.

I add an explict match for all newlines, in order to introduce the text
and the :newline tag.

As a side effect, the output has a bit more newlines as well.