### PR TITLE
Don't append trailing newlines

### DIFF
--- a/lib/erbse/parser.rb
+++ b/lib/erbse/parser.rb
@@ -29,7 +29,7 @@ module Erbse
         pos  = match.end(0)
         ch   = indicator ? indicator[0] : nil
 
-        if newline
+        if newline && !text.empty?
           buffers.last << [:static, "#{text}\n"] << [:newline]
           next
         end


### PR DESCRIPTION
Where `text` is empty, we don't need to be adding trailing newlines to
the `buffers` as this ends up adding more newlines than what is needed.

@fsateler I think your changes over in #12 introduced this so wanting to 
confirm this doesn't break anything you're relying on.

If someone can point me at a test case update for this, I'd be grateful as 
I'm not fully across the syntax we're expecting here.
